### PR TITLE
Interfaz dos

### DIFF
--- a/include/DialogoEmpate.hh
+++ b/include/DialogoEmpate.hh
@@ -1,0 +1,16 @@
+#ifndef DIALOGOEMPATE_HH
+#define DIALOGOEMPATE_HH
+#include <wx/msgdlg.h>
+#include <VistaJuego.hh>
+
+class DialogoEmpate:public wxDialog{
+    public:
+    //Constructor
+    DialogoEmpate(VistaJuego* ventanaVista);
+    void continuar(wxCommandEvent& event);
+    void salir(wxCommandEvent& event);
+    VistaJuego* ventanaVista;
+};
+
+
+#endif

--- a/include/DialogoGanador.hh
+++ b/include/DialogoGanador.hh
@@ -1,0 +1,20 @@
+#ifndef DIALOGOGANADOR_HH
+#define DIALOGOGANADOR_HH
+#include <wx/msgdlg.h>
+#include <VistaJuego.hh>
+#include <string>
+
+
+class DialogoGanador:public wxDialog{
+    public:
+    //Constructor
+    DialogoGanador(VistaJuego* ventanaVista,string nombreJugador);
+
+    private:
+    void continuar(wxCommandEvent& event);
+    void salir(wxCommandEvent& event);
+    VistaJuego* ventanaVista;
+    string nombreJugador;
+};
+
+#endif

--- a/include/VistaJuego.hh
+++ b/include/VistaJuego.hh
@@ -1,6 +1,7 @@
 #ifndef VISTAJUEGO_HH
 #define VISTAJUEGO_HH
 #include <wx/wx.h>
+#include <wx/timer.h>
 #include <memory>
 #include <EstadoJuego.hh>
 #include <ConfNuevoJuego.hh>
@@ -14,13 +15,23 @@ class VistaJuego : public wxFrame {
   VistaJuego(ConfNuevoJuego* confNuevoJuego,const wxString title, unique_ptr<EstadoJuego> estado);
   unique_ptr<EstadoJuego> estadoActual;
  private:
+ //métodos 
   void onPaint(wxPaintEvent& event);
   void onClick(wxMouseEvent& event);
+  void onTimer(wxTimerEvent& event);
+  void animacion(int columna, int color);
+  void onClose(wxCloseEvent& event);
+  //atributos
   wxPanel* espacioTablero;
   wxStaticText* turno;
   ConfNuevoJuego* confNuevoJuego;
-  void onClose(wxCloseEvent& event);
-
+  int columna;
+  int fila;
+  int colorFicha;
+  wxTimer* timer;
+  bool hayAnimacion;
+  int valEjeY;
+  
 };
 
 #endif

--- a/include/VistaJuego.hh
+++ b/include/VistaJuego.hh
@@ -21,6 +21,10 @@ class VistaJuego : public wxFrame {
   unique_ptr<EstadoJuego> estadoActual;
   ConfNuevoJuego* confNuevoJuego;
   void onClose(wxCloseEvent& event);
+  void dialogoEmpate();
+  void dialogoGanador();
+  void nuevoJuego(wxCommandEvent& event);
+  void botonSalir(wxCommandEvent& event);
 };
 
 #endif

--- a/include/VistaJuego.hh
+++ b/include/VistaJuego.hh
@@ -12,19 +12,15 @@ enviarle los inputs del usuario a controlar,
 class VistaJuego : public wxFrame {
  public:
   VistaJuego(ConfNuevoJuego* confNuevoJuego,const wxString title, unique_ptr<EstadoJuego> estado);
-
+  unique_ptr<EstadoJuego> estadoActual;
  private:
   void onPaint(wxPaintEvent& event);
   void onClick(wxMouseEvent& event);
   wxPanel* espacioTablero;
   wxStaticText* turno;
-  unique_ptr<EstadoJuego> estadoActual;
   ConfNuevoJuego* confNuevoJuego;
   void onClose(wxCloseEvent& event);
-  void dialogoEmpate();
-  void dialogoGanador();
-  void nuevoJuego(wxCommandEvent& event);
-  void botonSalir(wxCommandEvent& event);
+
 };
 
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,8 @@ set(SRCS
     EstadoJuego.cpp
     VistaJuego.cpp
     ConfNuevoJuego.cpp
+    DialogoEmpate.cpp
+    DialogoGanador.cpp
 )
 
 if(APPLE)

--- a/src/ConfNuevoJuego.cpp
+++ b/src/ConfNuevoJuego.cpp
@@ -12,6 +12,7 @@ ConfNuevoJuego::ConfNuevoJuego(MainFrame* mainFrame, const wxString& title)
   numFilasTablero = numColumnasTablero = 4;
 
   wxPanel* panelPrincipal = new wxPanel(this);
+  panelPrincipal->SetBackgroundColour((wxColour("#07c3ed")));
 
   wxBoxSizer* panelVertical = new wxBoxSizer(wxVERTICAL);
   wxBoxSizer* panelHorizontal = new wxBoxSizer(wxHORIZONTAL);

--- a/src/ConfNuevoJuego.cpp
+++ b/src/ConfNuevoJuego.cpp
@@ -101,7 +101,7 @@ ConfNuevoJuego::ConfNuevoJuego(MainFrame* mainFrame, const wxString& title)
   botonRegresar->Bind(wxEVT_BUTTON, &ConfNuevoJuego::botonRegresar, this);
  
 
-  //Maximize(true);
+  Maximize(true);
 }
 
 // manejo de eventos

--- a/src/ConfNuevoJuego.cpp
+++ b/src/ConfNuevoJuego.cpp
@@ -101,7 +101,7 @@ ConfNuevoJuego::ConfNuevoJuego(MainFrame* mainFrame, const wxString& title)
   botonRegresar->Bind(wxEVT_BUTTON, &ConfNuevoJuego::botonRegresar, this);
  
 
-  Maximize(true);
+  //Maximize(true);
 }
 
 // manejo de eventos

--- a/src/DialogoEmpate.cpp
+++ b/src/DialogoEmpate.cpp
@@ -1,0 +1,53 @@
+#include <DialogoEmpate.hh>
+#include <VistaJuego.hh>
+#include <wx/msgdlg.h>
+
+DialogoEmpate::DialogoEmpate(VistaJuego* ventanaVista):
+    wxDialog(ventanaVista, wxID_ANY,"", wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE ),ventanaVista(ventanaVista){
+        wxBoxSizer* vertical=new wxBoxSizer(wxVERTICAL);
+
+    wxStaticText* empateGrande= new wxStaticText(this,wxID_ANY,"EMPATE!");
+    wxStaticText* empatePregunta= new wxStaticText(this,wxID_ANY,"Ha sucedido un empate, Deseas continuar o salir",wxDefaultPosition);
+    wxFont fuenteEmpate(wxFontInfo(15).Bold().FaceName("Georgia"));
+    empateGrande->SetFont(fuenteEmpate);
+
+    wxBoxSizer* horizontal=new wxBoxSizer(wxHORIZONTAL);
+    wxButton* continuar=new wxButton(this,wxID_ANY, "Continuar",wxDefaultPosition);
+    wxButton* salir=new wxButton(this, wxID_ANY, "SALIR",wxDefaultPosition);
+  
+    horizontal->AddStretchSpacer();
+    horizontal->Add(continuar,0,wxALL | wxEXPAND,10);
+    horizontal->AddStretchSpacer();
+    horizontal->Add(salir,0, wxALL | wxEXPAND,10);
+    horizontal->AddStretchSpacer();
+
+    vertical->Add(empateGrande,0,wxALL | wxALIGN_CENTER_HORIZONTAL,10);
+    vertical->Add(empatePregunta,0,wxALL | wxALIGN_CENTER_HORIZONTAL,10);
+    vertical->AddStretchSpacer();
+    vertical->Add(horizontal,0,wxALL| wxEXPAND,10 );
+
+    this->SetSizer(vertical);
+    this->Fit();
+
+    continuar->Bind(wxEVT_BUTTON,&DialogoEmpate::continuar,this);
+    salir->Bind(wxEVT_BUTTON,&DialogoEmpate::salir,this);
+
+
+}
+
+
+ void DialogoEmpate::continuar(wxCommandEvent& event){
+    //aquí requerimos algo como VistaJuego->estadoActual->clearTablero();
+    //¿Se le puede enviar desde aquí un refresh? 
+ }
+
+void DialogoEmpate::salir(wxCommandEvent& event){
+//verificamos que vista no sea un puntero nulo
+if (ventanaVista) {
+        ventanaVista->Close(true);
+        //nos aseguramos que no siga existiendo el puntero a ventana vista 
+        ventanaVista = nullptr;
+    } 
+    //cerramos el dialogo
+    EndModal(wxID_CANCEL);
+}

--- a/src/DialogoGanador.cpp
+++ b/src/DialogoGanador.cpp
@@ -1,0 +1,56 @@
+#include <DialogoGanador.hh>
+#include <VistaJuego.hh>
+#include <wx/msgdlg.h>
+
+DialogoGanador::DialogoGanador(VistaJuego* ventanaVista,std::string nombreJugador):
+    wxDialog(ventanaVista, wxID_ANY,"", wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE ),ventanaVista(ventanaVista),nombreJugador(nombreJugador){
+    
+    wxBoxSizer* vertical=new wxBoxSizer(wxVERTICAL);
+
+    std::string mensajeGanador= nombreJugador + " ha GANADO!" ;
+
+    wxStaticText* textoVictoria= new wxStaticText(this,wxID_ANY,mensajeGanador);
+    wxStaticText* pregunta= new wxStaticText(this,wxID_ANY,"Deseas continuar o salir",wxDefaultPosition);
+    wxFont fuenteVictoria(wxFontInfo(15).Bold().FaceName("Georgia"));
+    textoVictoria->SetFont(fuenteVictoria);
+
+    wxBoxSizer* horizontal=new wxBoxSizer(wxHORIZONTAL);
+    wxButton* continuar=new wxButton(this,wxID_ANY, "Continuar",wxDefaultPosition);
+    wxButton* salir=new wxButton(this, wxID_ANY, "SALIR",wxDefaultPosition);
+  
+    horizontal->AddStretchSpacer();
+    horizontal->Add(continuar,0,wxALL | wxEXPAND,10);
+    horizontal->AddStretchSpacer();
+    horizontal->Add(salir,0, wxALL | wxEXPAND,10);
+    horizontal->AddStretchSpacer();
+
+    vertical->Add(textoVictoria,0,wxALL | wxALIGN_CENTER_HORIZONTAL,10);
+    vertical->Add(pregunta,0,wxALL | wxALIGN_CENTER_HORIZONTAL,10);
+    vertical->AddStretchSpacer();
+    vertical->Add(horizontal,0,wxALL| wxEXPAND,10 );
+
+    this->SetSizer(vertical);
+    this->Fit();
+
+    continuar->Bind(wxEVT_BUTTON,&DialogoGanador::continuar,this);
+    salir->Bind(wxEVT_BUTTON,&DialogoGanador::salir,this);
+
+
+}
+
+
+ void DialogoGanador::continuar(wxCommandEvent& event){
+    //aquí requerimos algo como VistaJuego->estadoActual->clearTablero();
+    //¿Se le puede enviar desde aquí un refresh? 
+ }
+
+void DialogoGanador::salir(wxCommandEvent& event){
+//verificamos que vista no sea un puntero nulo
+if (ventanaVista) {
+        ventanaVista->Close(true);
+        //nos aseguramos que no siga existiendo el puntero a ventana vista 
+        ventanaVista = nullptr;
+    } 
+    //cerramos el dialogo
+    EndModal(wxID_CANCEL);
+}

--- a/src/MainFrame.cpp
+++ b/src/MainFrame.cpp
@@ -8,10 +8,19 @@ MainFrame::MainFrame(const wxString& title)
               wxDEFAULT_FRAME_STYLE | wxRESIZE_BORDER | wxMAXIMIZE_BOX |
                   wxMINIMIZE_BOX) {
   wxPanel* panelPrincipal = new wxPanel(this);
+  panelPrincipal->SetBackgroundColour((wxColour("#07c3ed")));
+
+  wxFont fuenteT(wxFontInfo(50).Bold().FaceName("Bangers"));
+
+  wxStaticText* msjBienvenida =
+      new wxStaticText(panelPrincipal, wxID_ANY,
+                       "Bienvenid@s a 4 en Linea!", wxDefaultPosition);
+  msjBienvenida->SetFont(fuenteT);
 
   // creando fuente para el texto de los botones
   wxFont fuenteBotones(wxFontInfo(30).Bold().FaceName("Arial"));
 
+  
   wxBoxSizer* panelVertical = new wxBoxSizer(wxVERTICAL);
   wxBoxSizer* panelHorizontal = new wxBoxSizer(wxHORIZONTAL);
 
@@ -28,7 +37,8 @@ MainFrame::MainFrame(const wxString& title)
   nuevoJuegoBoton->Bind(wxEVT_BUTTON, &MainFrame::nuevoJuego, this);
   salirBoton->Bind(wxEVT_BUTTON, &MainFrame::salir, this);
   
-
+  panelVertical->AddStretchSpacer();
+  panelVertical->Add(msjBienvenida,0, wxALL | wxEXPAND, 10);
   panelVertical->AddStretchSpacer();
   panelVertical->Add(nuevoJuegoBoton, 0, wxALL | wxEXPAND, 10);
   panelVertical->Add(salirBoton, 0, wxALL | wxEXPAND, 10);

--- a/src/MainFrame.cpp
+++ b/src/MainFrame.cpp
@@ -43,7 +43,7 @@ MainFrame::MainFrame(const wxString& title)
   panelPrincipal->SetSizer(panelHorizontal);
 
   // que inicialmente este maximizado
-  //Maximize(true);
+  Maximize(true);
 }
 
 void MainFrame::nuevoJuego(wxCommandEvent& event) {

--- a/src/VistaJuego.cpp
+++ b/src/VistaJuego.cpp
@@ -178,7 +178,7 @@ void VistaJuego::onClick(wxMouseEvent& event){
     wxLogMessage("Clic en la columna %d", columnaClick);
 
 
-    DialogoGanador* ganador= new DialogoGanador(this, "Joshua");
+    DialogoGanador* ganador= new DialogoGanador(this, "Jugador 1");
     ganador->ShowModal();
     // DialogoEmpate* empate= new DialogoEmpate(this);
     // empate->ShowModal();

--- a/src/VistaJuego.cpp
+++ b/src/VistaJuego.cpp
@@ -1,5 +1,6 @@
 #include <wx/dcbuffer.h>
 #include <wx/wx.h>
+#include <wx/timer.h>
 #include <EstadoJuego.hh>
 #include <DialogoEmpate.hh>
 #include <DialogoGanador.hh>
@@ -72,6 +73,38 @@ VistaJuego::VistaJuego(ConfNuevoJuego* confNuevoJuego,const wxString title, uniq
   Maximize(true);
 }
 
+//método que se llama cuando se va a insertar una ficha, inicializa la animación y los valores que se ocupan para ella
+//recibe en que columna se quiere insertar la ficha, así como el color del jugador que la está insertando
+//se establecio: 1=amarillo, 2=rojo
+void VistaJuego::animacion(int columna, int color){
+  columna=columna;
+  color=color;
+  //el eje Y de la pantalla va a estar originalmente en 0 para que caiga desde arriba
+  valEjeY=0;
+  hayAnimacion=true;
+  //TODO: Correción en estado para que insertarFicha devuelva int
+  //insertarficha me devuelve el entero donde se insertar la ficha en la lógica, aquí lo usamos para saber hasta que fila debe de llegar la ficha en su caída
+  //fila=estadoActual->insertarFicha();
+
+  //vamos a llamar a onTimer cada 16 milisegundos
+  timer->Start(16);
+}
+
+//Método que actualiza la posición de la ficha en cada intervalo de tiempo definido por el wxtimer
+
+void VistaJuego::onTimer(wxTimerEvent& event){
+
+  //vamos a ir incrementando la posición de la ficha en el ejeY
+  valEjeY=valEjeY+5;
+
+  //si el valor de la ficha en el eje Y llega al valor del eje Y de la fila correspondiente o se pasa detenemos la animación y el timer
+
+}
+
+
+
+
+
 // método que se va a llamar cada que el tablero ocupe ser redibujado- por
 // ejemplo que tenga que cambiar de tamaño
 void VistaJuego::onPaint(wxPaintEvent& event) {
@@ -128,6 +161,10 @@ void VistaJuego::onPaint(wxPaintEvent& event) {
   }
 }
 
+
+
+
+
 void VistaJuego::onClick(wxMouseEvent& event){
 
     int anchoPanel=espacioTablero->GetClientSize().GetWidth();
@@ -163,10 +200,13 @@ void VistaJuego::onClick(wxMouseEvent& event){
 
 }
 
+
+
 void VistaJuego::onClose(wxCloseEvent& event){
   if (confNuevoJuego){
       confNuevoJuego->Close(true);
   }
   event.Skip();
 }
+
 

--- a/src/VistaJuego.cpp
+++ b/src/VistaJuego.cpp
@@ -66,8 +66,8 @@ VistaJuego::VistaJuego(ConfNuevoJuego* confNuevoJuego,const wxString title, uniq
   this->SetSizerAndFit(panelVertical);
 
   
-
-  //Maximize(true);
+  //que incialmente este maximizado
+  Maximize(true);
 }
 
 // método que se va a llamar cada que el tablero ocupe ser redibujado- por
@@ -129,7 +129,11 @@ void VistaJuego::onClick(wxMouseEvent& event){
     int coordX=event.GetX();
     //covertimos coordenada en columna
     int columnaClick= coordX/anchoCelda;
+    
     wxLogMessage("Clic en la columna %d", columnaClick);
+
+  
+    dialogoEmpate();
 
     if(estadoActual->insertarFicha(columnaClick)){
       //Sí pudimos insertar ficha, así que con refresh encolamos evento de dibujar
@@ -139,8 +143,7 @@ void VistaJuego::onClick(wxMouseEvent& event){
     if(estadoActual->verificarGanador()){
     
       }else if(estadoActual->empate()){
-
-
+      
       }else{
         // estadoActual->cambiarTurno();
         // turno->SetLabel("falta método para obtener nombre del jugador actual");
@@ -154,4 +157,58 @@ void VistaJuego::onClose(wxCloseEvent& event){
       confNuevoJuego->Close(true);
   }
   event.Skip();
+}
+
+void VistaJuego::dialogoEmpate(){
+    
+    wxDialog* dialogoEmpate= new wxDialog (this,wxID_ANY,"",wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE);
+    wxBoxSizer* vertical=new wxBoxSizer(wxVERTICAL);
+
+    wxStaticText* empateGrande= new wxStaticText(dialogoEmpate,wxID_ANY,"EMPATE!");
+    wxStaticText* empatePregunta= new wxStaticText(dialogoEmpate,wxID_ANY,"Ha sucedido un empate ¿Deseas reiniciar o salir?",wxDefaultPosition);
+    wxFont fuenteEmpate(wxFontInfo(15).Bold().FaceName("Georgia"));
+    empateGrande->SetFont(fuenteEmpate);
+
+    wxBoxSizer* horizontal=new wxBoxSizer(wxHORIZONTAL);
+    wxButton* nuevoJuego=new wxButton(dialogoEmpate,wxID_ANY, "NUEVO",wxDefaultPosition);
+    wxButton* salir=new wxButton(dialogoEmpate, wxID_ANY, "SALIR",wxDefaultPosition);
+    
+  
+    horizontal->AddStretchSpacer();
+    horizontal->Add(nuevoJuego,0,wxALL | wxEXPAND,10);
+    horizontal->AddStretchSpacer();
+    horizontal->Add(salir,0, wxALL | wxEXPAND,10);
+    horizontal->AddStretchSpacer();
+
+
+    vertical->Add(empateGrande,0,wxALL | wxALIGN_CENTER_HORIZONTAL,10);
+    vertical->Add(empatePregunta,0,wxALL | wxALIGN_CENTER_HORIZONTAL,10);
+    vertical->AddStretchSpacer();
+    vertical->Add(horizontal,0,wxALL| wxEXPAND,10 );
+
+    
+
+    dialogoEmpate->SetSizer(vertical);
+    dialogoEmpate->Fit();
+
+
+    nuevoJuego->Bind(wxEVT_BUTTON,&VistaJuego::nuevoJuego,this);
+    salir->Bind(wxEVT_BUTTON,&VistaJuego::botonSalir,this);
+
+    dialogoEmpate->ShowModal();
+
+    delete dialogoEmpate; 
+    
+}
+
+void VistaJuego::dialogoGanador(){
+
+}
+
+void VistaJuego::nuevoJuego(wxCommandEvent& event){
+  wxLogMessage("Presionaron nuevo desde dialog");
+}
+
+void VistaJuego::botonSalir(wxCommandEvent& event){
+  wxLogMessage("Presionaron salir desde dialog");
 }

--- a/src/VistaJuego.cpp
+++ b/src/VistaJuego.cpp
@@ -1,6 +1,8 @@
 #include <wx/dcbuffer.h>
 #include <wx/wx.h>
 #include <EstadoJuego.hh>
+#include <DialogoEmpate.hh>
+#include <DialogoGanador.hh>
 #include <memory>
 #include <VistaJuego.hh>
 
@@ -104,14 +106,20 @@ void VistaJuego::onPaint(wxPaintEvent& event) {
   // vamos a establecer el lápiz que se usa en el buffer para dibujar los
   // circulos del tablero
   bufferDibujo.SetPen(wxPen(*wxBLACK, 2));
-  // establecemos brush para rellenar las celdas
-  bufferDibujo.SetBrush(*wxWHITE_BRUSH);
+
 
   // vamos a ir iterando para dibujar los circulos en cada celda del tablero
   // vamos rellenando por filas
 
   for (int i = 0; i < estadoActual->columnas; i++) {
     for (int j = 0; j < estadoActual->filas; j++) {
+      if(estadoActual->estadoCelda(i,j)==1){
+        bufferDibujo.SetBrush(*wxYELLOW_BRUSH);
+      }else if(estadoActual->estadoCelda(i,j)==2){
+        bufferDibujo.SetBrush(*wxRED_BRUSH);
+      }else{
+          bufferDibujo.SetBrush(*wxWHITE_BRUSH);
+      }
       // calculamos el eje x del centro del circulo
       int ejeX = i * anchoCelda + anchoCelda / 2;
       int ejeY = j * alturaCelda + alturaCelda / 2;
@@ -132,8 +140,11 @@ void VistaJuego::onClick(wxMouseEvent& event){
     
     wxLogMessage("Clic en la columna %d", columnaClick);
 
-  
-    dialogoEmpate();
+
+    DialogoGanador* ganador= new DialogoGanador(this, "Joshua");
+    ganador->ShowModal();
+    // DialogoEmpate* empate= new DialogoEmpate(this);
+    // empate->ShowModal();
 
     if(estadoActual->insertarFicha(columnaClick)){
       //Sí pudimos insertar ficha, así que con refresh encolamos evento de dibujar
@@ -159,56 +170,3 @@ void VistaJuego::onClose(wxCloseEvent& event){
   event.Skip();
 }
 
-void VistaJuego::dialogoEmpate(){
-    
-    wxDialog* dialogoEmpate= new wxDialog (this,wxID_ANY,"",wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE);
-    wxBoxSizer* vertical=new wxBoxSizer(wxVERTICAL);
-
-    wxStaticText* empateGrande= new wxStaticText(dialogoEmpate,wxID_ANY,"EMPATE!");
-    wxStaticText* empatePregunta= new wxStaticText(dialogoEmpate,wxID_ANY,"Ha sucedido un empate ¿Deseas reiniciar o salir?",wxDefaultPosition);
-    wxFont fuenteEmpate(wxFontInfo(15).Bold().FaceName("Georgia"));
-    empateGrande->SetFont(fuenteEmpate);
-
-    wxBoxSizer* horizontal=new wxBoxSizer(wxHORIZONTAL);
-    wxButton* nuevoJuego=new wxButton(dialogoEmpate,wxID_ANY, "NUEVO",wxDefaultPosition);
-    wxButton* salir=new wxButton(dialogoEmpate, wxID_ANY, "SALIR",wxDefaultPosition);
-    
-  
-    horizontal->AddStretchSpacer();
-    horizontal->Add(nuevoJuego,0,wxALL | wxEXPAND,10);
-    horizontal->AddStretchSpacer();
-    horizontal->Add(salir,0, wxALL | wxEXPAND,10);
-    horizontal->AddStretchSpacer();
-
-
-    vertical->Add(empateGrande,0,wxALL | wxALIGN_CENTER_HORIZONTAL,10);
-    vertical->Add(empatePregunta,0,wxALL | wxALIGN_CENTER_HORIZONTAL,10);
-    vertical->AddStretchSpacer();
-    vertical->Add(horizontal,0,wxALL| wxEXPAND,10 );
-
-    
-
-    dialogoEmpate->SetSizer(vertical);
-    dialogoEmpate->Fit();
-
-
-    nuevoJuego->Bind(wxEVT_BUTTON,&VistaJuego::nuevoJuego,this);
-    salir->Bind(wxEVT_BUTTON,&VistaJuego::botonSalir,this);
-
-    dialogoEmpate->ShowModal();
-
-    delete dialogoEmpate; 
-    
-}
-
-void VistaJuego::dialogoGanador(){
-
-}
-
-void VistaJuego::nuevoJuego(wxCommandEvent& event){
-  wxLogMessage("Presionaron nuevo desde dialog");
-}
-
-void VistaJuego::botonSalir(wxCommandEvent& event){
-  wxLogMessage("Presionaron salir desde dialog");
-}


### PR DESCRIPTION
Se crearon dos nuevas clases wxDialog:

- DialogoGanador Para manejar la situación cuando el juego termina en empate.

- DialogoEmpate: Para manejar la situación cuando hay un ganador.

Aún falta implementar el botón "Continuar" en ambos diálogos, ya que requiere del método clearTablero del estado del juego.
En GanadorDialog falta corregir el tamaño del diálogo.

Se iniciaron los métodos para la animación de la caída de las fichas en el tablero.

Se implementó el estado de las fichas para pintar las fichas de acuerdo al jugador que se encuentra en el tablero.

Es necesario merge porque para continuar se requiere de varios métodos y funciones del estado.
