### PR TITLE
Corregir columna

### DIFF
--- a/include/EstadoJuego.hh
+++ b/include/EstadoJuego.hh
@@ -48,6 +48,9 @@ class EstadoJuego {
   // "2". Devuelve -1 si no se encontró al jugador.
   int getGanes(string nombreJugador);
 
+  // devuelve verdadero si jugadorActual es humano.
+  bool esHumano();
+
   // atributos
   shared_ptr<IJugador> jugadorActual;
   shared_ptr<IJugador> jugadorUno;

--- a/include/EstadoJuego.hh
+++ b/include/EstadoJuego.hh
@@ -21,7 +21,7 @@ class EstadoJuego {
   // método que regresa el número del enum que ocupe la celda.
   int estadoCelda(int fila, int columna);
 
-  // método que inserta la ficha en el tablero y devuelve la columna en la que
+  // método que inserta la ficha en el tablero y devuelve la fila en la que
   // se logró insertar.
   int insertarFicha(int columna);
 

--- a/src/EstadoJuego.cpp
+++ b/src/EstadoJuego.cpp
@@ -52,12 +52,12 @@ int EstadoJuego::insertarFicha(int columna) {
     int FilaInsertada = tablero.insertarFicha(amarillo, columna);
     ultimaFilaInsertada = FilaInsertada;
     ultimaColumnaInsertada = columna;
-    return columna;
+    return FilaInsertada;
   } else if (jugadorActual == jugadorDos) {
     int FilaInsertada = tablero.insertarFicha(rojo, columna);
     ultimaFilaInsertada = FilaInsertada;
     ultimaColumnaInsertada = columna;
-    return columna;
+    return FilaInsertada;
   }
 
   return -1;

--- a/src/EstadoJuego.cpp
+++ b/src/EstadoJuego.cpp
@@ -110,3 +110,17 @@ int EstadoJuego::getGanes(string nombre) {
 
   return -1;
 }
+
+bool EstadoJuego::esHumano() {
+  if (jugadorActual == jugadorUno) {
+    if (tipoJugador1 == 0) {
+      return true;
+    }
+  } else if (jugadorActual == jugadorDos) {
+    if (tipoJugador2 == 0) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/tests/test_Estados.cpp
+++ b/tests/test_Estados.cpp
@@ -314,3 +314,29 @@ TEST(EstadoTest, getJugadorConTurno) {
   int jugador2 = juego.getTipoJugador();
   EXPECT_EQ(jugador2, 0);
 }
+
+TEST(EstadoTest, getJugadorHumano1) {
+  EstadoJuego juego = EstadoJuego(2, 2, 0, 0);
+  bool jugador1 = juego.esHumano();
+  EXPECT_TRUE(jugador1);
+}
+
+TEST(EstadoTest, getJugadorNoHumano1) {
+  EstadoJuego juego = EstadoJuego(2, 2, 1, 0);
+  bool jugador1 = juego.esHumano();
+  EXPECT_FALSE(jugador1);
+}
+
+TEST(EstadoTest, getJugadorHumano2) {
+  EstadoJuego juego = EstadoJuego(2, 2, 1, 0);
+  juego.cambiarTurno();
+  bool jugador2 = juego.esHumano();
+  EXPECT_TRUE(jugador2);
+}
+
+TEST(EstadoTest, getJugadorNoHumano2) {
+  EstadoJuego juego = EstadoJuego(2, 2, 1, 2);
+  juego.cambiarTurno();
+  bool jugador2 = juego.esHumano();
+  EXPECT_FALSE(jugador2);
+}


### PR DESCRIPTION
en insertarFicha de estados ahora devuelve la columna en la que se logró insertar la ficha y no la columna