### PR TITLE
Ajuste de profundidad para minimax

### DIFF
--- a/src/JugadorDificil.cpp
+++ b/src/JugadorDificil.cpp
@@ -234,5 +234,5 @@ int JugadorDificil::jugar(Tablero tablero) {
       std ::chrono ::system_clock::now());
   // se elige hasa el momento una profundidad de tres hasta el momento
   // la IA tiene un tiempo máximo de procesamiento de 0.9s
-  return minimax(tiempoInicio, 0.9, tablero, 3, INT_MIN, INT_MAX, ficha)[0];
+  return minimax(tiempoInicio, 0.9, tablero, 1, INT_MIN, INT_MAX, ficha)[0];
 }


### PR DESCRIPTION
Se cambió la profundidad a 1 para que la IA Dificil en la medida de lo posible pueda evaluar las columnas ubicadas en la sección derecha del tablero
